### PR TITLE
Add an explainer for TTL in each record table

### DIFF
--- a/src/data/record_key_help.ts
+++ b/src/data/record_key_help.ts
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import i18n from "../i18n"
+
 export default {
-    TTL: "Time-to-live is a value in seconds that indicates how long a record should be cached for before being checked again",
-}
+    TTL: i18n.data.recordKeyHelp.TTL,
+} as {[key: string]: string}

--- a/src/data/record_key_help.ts
+++ b/src/data/record_key_help.ts
@@ -18,4 +18,4 @@ import i18n from "../i18n"
 
 export default {
     TTL: i18n.data.recordKeyHelp.TTL,
-} as {[key: string]: string}
+}

--- a/src/data/record_key_help.ts
+++ b/src/data/record_key_help.ts
@@ -1,0 +1,19 @@
+/*
+Copyright 2019 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export default {
+    TTL: "Time-to-live is a value in seconds that indicates how long a record should be cached for before being checked again",
+}

--- a/src/i18n/en/data/index.ts
+++ b/src/i18n/en/data/index.ts
@@ -1,6 +1,7 @@
 import txt from "./txt"
 import records from "./records"
+import recordKeyHelp from "./record_key_help"
 
 export default {
-    txt, records,
+    txt, records, recordKeyHelp,
 } as {[key: string]: {[key: string]: string}}

--- a/src/i18n/en/data/record_key_help.ts
+++ b/src/i18n/en/data/record_key_help.ts
@@ -1,0 +1,3 @@
+export default {
+    TTL: "Time-to-live is a value in seconds that indicates how long a record should be cached for before being checked again",
+} as {[key: string]: string}

--- a/src/templates/record.vue
+++ b/src/templates/record.vue
@@ -43,8 +43,11 @@ limitations under the License.
                         <tr>
                             <th v-for="recordKey in recordKeys">
                                 {{ recordKey }}
-                                <i v-if="recordKey in recordKeyHelp" :title="recordKeyHelp[recordKey]" v-tippy
-                                   class="far fa-question-circle"></i>
+                                <i v-if="recordKey in recordKeyHelp"
+                                   v-tippy
+                                   :title="recordKeyHelp[recordKey]"
+                                   class="far fa-question-circle"
+                                ></i>
                             </th>
                         </tr>
                     </thead>

--- a/src/templates/record.vue
+++ b/src/templates/record.vue
@@ -14,6 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+<style scoped>
+    i.fa-question-circle:hover {
+        cursor: pointer;
+    }
+</style>
+
 <template>
     <span>
         <span v-if="active">
@@ -37,6 +43,8 @@ limitations under the License.
                         <tr>
                             <th v-for="recordKey in recordKeys">
                                 {{ recordKey }}
+                                <i v-if="recordKey in recordKeyHelp" :title="recordKeyHelp[recordKey]" v-tippy
+                                   class="far fa-question-circle"></i>
                             </th>
                         </tr>
                     </thead>
@@ -94,6 +102,7 @@ limitations under the License.
     import standardiseRecords from "../standardise_records"
     import { getLargestRecordPart } from "../table"
     import records from "../data/records"
+    import recordKeyHelp from "../data/record_key_help"
     import txtFragments from "../data/txt"
     import registrarRegexp from "../data/registrar_regexp"
     import nsRegexp from "../data/ns_regexp"
@@ -149,6 +158,7 @@ limitations under the License.
                 recordRows: [],
                 dnsDifferences: [],
                 learnMore: null,
+                recordKeyHelp,
                 i18n,
             }
         },


### PR DESCRIPTION
This pull request implements a new data structure that allows for help icons to be shown next to record table headers (keys).

This is used currently to display the TTL explainer message only.

Fixes #47 

![image](https://user-images.githubusercontent.com/12371363/62771269-c2583e80-ba94-11e9-849d-a1bafb2eda86.png)
