### PR TITLE
Disable Parcel minification as it breaks SVG symbols

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "fetch-template": "node build/fetchTemplate.js",
-    "build": "npm run fetch-template && parcel build ./src/index.html --public-url=./",
+    "build": "npm run fetch-template && parcel build ./src/index.html --public-url=./ --no-minify",
     "dev": "npm run fetch-template && parcel ./src/index.html",
     "lint": "tsc && eslint ./src/**/*.ts && eslint ./src/**/*.vue",
     "lint-and-fix": "tsc && eslint ./src/**/*.ts --fix && eslint ./src/**/*.vue --fix"


### PR DESCRIPTION
This disables Parcel's minification as this appears to break SVG symbol definitions. Some discussion of this can be found in https://github.com/parcel-bundler/parcel/issues/703