### PR TITLE
Migrate from cfwho.com to abuse.ts.cfdata.org

### DIFF
--- a/src/templates/whois.vue
+++ b/src/templates/whois.vue
@@ -37,7 +37,7 @@ limitations under the License.
 </template>
 
 <script>
-    import cfWHO from "../utils/cfWHO"
+    import cfAbuseData from "../utils/cfAbuseData"
     import geoJS from "../utils/geoJS"
     import VueTippy from "vue-tippy"
     import Vue from "vue"
@@ -76,7 +76,7 @@ limitations under the License.
                 this.$data.expand = !this.$data.expand
             },
             async handleInit() {
-                const json = await (await cfWHO(this.$props.ip)).json()
+                const json = await (await cfAbuseData(this.$props.ip)).json()
                 const geoIpJson = await (await geoJS(this.$props.ip)).json()
                 this.countryCode = geoIpJson.country_code ? geoIpJson.country_code.toLowerCase() : ""
                 this.netname = json.results[0].netname ? json.results[0].netname : i18n.templates.whois.notSpecified

--- a/src/utils/cfAbuseData.ts
+++ b/src/utils/cfAbuseData.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 export default async (ip: string) => {
     return await fetch(
-        `https://cfwho.com/get/${ip}`,
+        `https://abuse.ts.cfdata.org/get/${ip}`,
         {
             headers: {
                 Accept: "application/json",


### PR DESCRIPTION
Per request from Cloudflare, migrate from cfwho.com to abuse.ts.cfdata.org as they're introducing new load balancing.