### PR TITLE
Update SRV record handling

### DIFF
--- a/src/i18n/en/templates/records.ts
+++ b/src/i18n/en/templates/records.ts
@@ -4,4 +4,6 @@ export default {
     propagation: "Why do I get different values on my local system?",
     learnHow: "Learn how to set {record} records with your DNS/registrar.",
     propagationNote: "Google DNS is reporting different values. This potentially means that your values have not propagated fully yet.",
+    srvFormat: `Expecting to see an SRV record here? Make sure you're looking at the right sub-domain.
+    <br/>SRV record names are normally formatted as follows: <code>_&lt;service&gt;._&lt;protocol&gt;.name.</code>`,
 } as {[key: string]: string}

--- a/src/scss/_typography.scss
+++ b/src/scss/_typography.scss
@@ -62,13 +62,16 @@ strong {
 
 // Code
 :not(pre) > code {
+  color: lighten($text, 20);
   font-size: 14px;
   font-family: $mono-font-family;
   white-space: nowrap;
-  padding: 0 2px;
+  padding: $margin * 0.75;
+  margin: ($margin * 0.5) 0;
   border: $thin-border;
   border-radius: $border-radius;
   background: $panel;
+  display: inline-block;
 }
 
 // Headings

--- a/src/standardise_records.ts
+++ b/src/standardise_records.ts
@@ -28,7 +28,7 @@ export default (key: string, json: any, txtRecordFragments: any, recordsJoined: 
         const newRecords = []
         for (const record of json.Answer) {
             const recordData = record.data.startsWith("\"") ? record.data.substr(1).slice(0, -1) : record.data
-            const dataSplit =  recordData.split(";")
+            const dataSplit = recordData.split(";")
             for (const newSplit of dataSplit) {
                 if (newSplit === "") continue
 
@@ -56,6 +56,15 @@ export default (key: string, json: any, txtRecordFragments: any, recordsJoined: 
                 delete json.Answer[record]
                 continue
             }
+        }
+    } else if (key === "SRV") {
+        for (const record of json.Answer) {
+            const dataSplit = record.data.split(" ").reverse()
+            record.priority = dataSplit.pop()
+            record.weight = dataSplit.pop()
+            record.port = dataSplit.pop()
+            record.target = dataSplit.reverse().join(" ")
+            delete record.data
         }
     }
 

--- a/src/templates/record.vue
+++ b/src/templates/record.vue
@@ -29,6 +29,7 @@ limitations under the License.
             </p>
             <div v-if="recordKeys.length === 0">
                 <p><b>{{ i18n.templates.records.noRecords }}</b></p>
+                <p v-if="this.$props.recordType === 'SRV'" v-html="i18n.templates.records.srvFormat"></p>
             </div>
             <div v-else>
                 <table class="table">


### PR DESCRIPTION
This pull request does the following:

 - Parses SRV records (identifying `Priority`, `Weight`, `Port` & `Target`)
 - Resolves #52 by adding a note when no SRV records are found about the standard SRV name format (`_<service>._<protocol>.name.`)