### PR TITLE
Add a scroll into view offset of 32px

### DIFF
--- a/src/spf-explainer/scss/style.scss
+++ b/src/spf-explainer/scss/style.scss
@@ -28,3 +28,7 @@ limitations under the License.
     top: $margin * 3;
   }
 }
+
+.spf-scroll-offset {
+  scroll-margin-top: 32px;
+}

--- a/src/spf-explainer/scss/style.scss
+++ b/src/spf-explainer/scss/style.scss
@@ -28,7 +28,3 @@ limitations under the License.
     top: $margin * 3;
   }
 }
-
-.spf-scroll-offset {
-  scroll-margin-top: 32px;
-}

--- a/src/spf-explainer/templates/spf.vue
+++ b/src/spf-explainer/templates/spf.vue
@@ -23,7 +23,7 @@ limitations under the License.
         </h5>
         <div v-for="part in parts" :key="part[0]">
             <hr class="hr-small-pad">
-            <div :ref="part[0]" class="spf-scroll-offset">
+            <div :ref="part[0]">
                 <p>
                     <code class="slim">{{ part[0] }}</code>
                     <a
@@ -102,7 +102,9 @@ limitations under the License.
             goToIndex(index) {
                 const refArr = this.$refs[this.$data.links[index]]
                 const ref = refArr[refArr.length - 1]
-                ref.scrollIntoView()
+                window.scrollTo({
+                    top: ref.getBoundingClientRect().y + window.pageYOffset - 32,
+                })
             },
             markActive(index) {
                 const from = this.$refs[index][0]

--- a/src/spf-explainer/templates/spf.vue
+++ b/src/spf-explainer/templates/spf.vue
@@ -23,7 +23,7 @@ limitations under the License.
         </h5>
         <div v-for="part in parts" :key="part[0]">
             <hr class="hr-small-pad">
-            <div :ref="part[0]">
+            <div :ref="part[0]" class="spf-scroll-offset">
                 <p>
                     <code class="slim">{{ part[0] }}</code>
                     <a


### PR DESCRIPTION
## Type of Change
<!-- What part of the source are you modifying? Remove the irrelevant options. -->

- **Tool Source:** SPF Explainer to add a scroll offset to the element.

## What issue does this relate to?
Fixes: #81

### What should this PR do?
- Add a scroll offset to the top of SPF elements.  This means that when it is scrolled into view, it will leave 32px at the top of the screen.

### What are the acceptance criteria?
That the scroll offset behaves properly.