### PR TITLE
Remove AWS CLI download action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,8 +33,6 @@ jobs:
         BRANCH: gh-pages
         FOLDER: dist
 
-    - uses: chrislennon/action-aws-cli@v1.1
-
     - name: Deploy commit to DigitalOcean Spaces
       run: aws s3 sync ./dist s3://${{ secrets.SPACES_BUCKET }}/${{ github.sha }} --endpoint=https://${{ secrets.SPACES_REGION }}.digitaloceanspaces.com --acl public-read --content-encoding utf8
       env:


### PR DESCRIPTION
## Type of Change
- **Build Scripts:** Removal of a redundant action being called.

## What issue does this relate to?
Accelerating the CI build time.

### What should this PR do?
Remove a redundant installer since the Ubuntu image which GitHub uses already has the AWS CLI.

### What are the acceptance criteria?
It successfully building (this can be seen by the commit itself).