### PR TITLE
Add a core modal template

### DIFF
--- a/src/dns-lookup/templates/clipboard_modal.vue
+++ b/src/dns-lookup/templates/clipboard_modal.vue
@@ -15,49 +15,41 @@ limitations under the License.
 -->
 
 <template>
-    <div :class="`modal${toggled ? ' is-active' : ''}`">
-        <div class="modal-background"></div>
-        <div class="modal-card">
-            <header class="modal-card-head">
-                <p class="modal-card-title">
-                    {{ i18n.templates.clipboardModal.clipboardResult }}
-                </p>
-                <button class="delete" :aria-label="i18n.common.close" @click="hide"></button>
-            </header>
-            <section class="modal-card-body">
-                <p>
-                    <span class="tag is-success">
-                        {{ i18n.templates.clipboardModal.thisHasBeenCopied }}
-                    </span>
-                </p>
-                <pre class="clipboard textarea has-fixed-size"><code>{{ textReport }}</code></pre>
-            </section>
-        </div>
-    </div>
+    <CoreModal ref="CoreModal" :title="i18n.templates.clipboardModal.clipboardResult">
+        <p>
+            <span class="tag is-success">
+                {{ i18n.templates.clipboardModal.thisHasBeenCopied }}
+            </span>
+        </p>
+        <pre class="clipboard textarea has-fixed-size"><code>{{ textReport }}</code></pre>
+    </CoreModal>
 </template>
 
 <script>
     import i18n from "../i18n"
+    import CoreModal from "../../shared/templates/core_modal"
 
     export default {
         name: "ClipboardModal",
+        components: {
+            CoreModal,
+        },
         data() {
             return {
                 textReport: "",
-                toggled: false,
                 i18n,
             }
         },
         methods: {
             show(textReport) {
                 this.$data.textReport = textReport
-                this.$data.toggled = true
+                this.$refs.CoreModal.toggle()
             },
             hide() {
-                this.$data.toggled = false
+                this.$refs.CoreModal.toggle()
             },
             showParent() {
-                this.$data.toggled = false
+                this.$refs.CoreModal.toggle()
                 this.$emit("toggle-root")
             },
         },

--- a/src/dns-lookup/templates/dmarc_explainer_modal.vue
+++ b/src/dns-lookup/templates/dmarc_explainer_modal.vue
@@ -15,49 +15,38 @@ limitations under the License.
 -->
 
 <template>
-    <div :class="`modal${toggled ? ' is-active' : ''}`">
-        <div class="modal-background"></div>
-        <div class="modal-card">
-            <header class="modal-card-head">
-                <p class="modal-card-title">
-                    {{ i18n.templates.dmarcExplainer.title }}
-                </p>
-                <button class="delete" :aria-label="i18n.common.close" @click="toggle"></button>
-            </header>
-            <section class="modal-card-body">
-                <div v-html="i18n.templates.dmarcExplainer.intro"></div>
-                <hr>
-                <p v-for="(value, key) in dmarc" :key="key">
-                    <b>{{ key }}</b>: <span v-html="value"></span>
-                </p>
-                <hr>
-                <p>
-                    {{ i18n.templates.dmarcExplainer.learnMore }}
-                    <ExternalLink link="https://dmarc.org/" text="dmarc.org"></ExternalLink>.
-                </p>
-            </section>
-        </div>
-    </div>
+    <CoreModal ref="CoreModal" :title="i18n.templates.dmarcExplainer.title">
+        <div v-html="i18n.templates.dmarcExplainer.intro"></div>
+        <hr>
+        <p v-for="(value, key) in dmarc" :key="key">
+            <b>{{ key }}</b>: <span v-html="value"></span>
+        </p>
+        <hr>
+        <p>
+            {{ i18n.templates.dmarcExplainer.learnMore }}
+            <ExternalLink link="https://dmarc.org/" text="dmarc.org"></ExternalLink>.
+        </p>
+    </CoreModal>
 </template>
 
 <script>
     import i18n from "../i18n"
     import dmarc from "../data/dmarc"
     import ExternalLink from "../../shared/templates/ext_link"
+    import CoreModal from "../../shared/templates/core_modal"
 
     export default {
         name: "DMARCExplainerModal",
-        components: { ExternalLink },
+        components: { CoreModal, ExternalLink },
         data() {
             return {
-                toggled: false,
                 i18n,
                 dmarc,
             }
         },
         methods: {
             toggle() {
-                this.$data.toggled = !this.$data.toggled
+                this.$refs.CoreModal.toggle()
             },
         },
     }

--- a/src/dns-lookup/templates/dns_diff.vue
+++ b/src/dns-lookup/templates/dns_diff.vue
@@ -15,7 +15,10 @@ limitations under the License.
 -->
 
 <template>
-    <CoreModal ref="CoreModal" :title="`${i18n.templates.dnsDiff.title} ${i18n.templates.dnsDiff.XRecords.replace('{record}', this.$props.recordType)}`">
+    <CoreModal
+        ref="CoreModal"
+        :title="`${i18n.templates.dnsDiff.title} ${i18n.templates.dnsDiff.XRecords.replace('{record}', this.$props.recordType)}`"
+    >
         <table class="table is-bordered">
             <thead>
                 <tr>

--- a/src/dns-lookup/templates/dns_diff.vue
+++ b/src/dns-lookup/templates/dns_diff.vue
@@ -15,55 +15,47 @@ limitations under the License.
 -->
 
 <template>
-    <div :class="`modal${toggled ? ' is-active' : ''}`">
-        <div class="modal-background"></div>
-        <div class="modal-card">
-            <header class="modal-card-head">
-                <p class="modal-card-title">
-                    {{ i18n.templates.dnsDiff.title }} {{ i18n.templates.dnsDiff.XRecords.replace("{record}", this.$props.recordType) }}
-                </p>
-                <button class="delete" :aria-label="i18n.common.close" @click="toggle"></button>
-            </header>
-            <section class="modal-card-body">
-                <table class="table is-bordered">
-                    <thead>
-                        <tr>
-                            <th>{{ i18n.templates.dnsDiff.host }}</th>
-                            <th>{{ i18n.templates.dnsDiff.cfDns }}</th>
-                            <th>{{ i18n.templates.dnsDiff.gDns }}</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr v-for="row in $props.dnsDifferences">
-                            <td v-for="value in row">
-                                <p>{{ value ? value : i18n.common.none }}</p>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </section>
-        </div>
-    </div>
+    <CoreModal ref="CoreModal" :title="`${i18n.templates.dnsDiff.title} ${i18n.templates.dnsDiff.XRecords.replace('{record}', this.$props.recordType)}`">
+        <table class="table is-bordered">
+            <thead>
+                <tr>
+                    <th>{{ i18n.templates.dnsDiff.host }}</th>
+                    <th>{{ i18n.templates.dnsDiff.cfDns }}</th>
+                    <th>{{ i18n.templates.dnsDiff.gDns }}</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr v-for="row in $props.dnsDifferences">
+                    <td v-for="value in row">
+                        <p>{{ value ? value : i18n.common.none }}</p>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </CoreModal>
 </template>
 
 <script>
     import i18n from "../i18n"
+    import CoreModal from "../../shared/templates/core_modal"
 
     export default {
         name: "DNSDiff",
+        components: {
+            CoreModal,
+        },
         props: {
             dnsDifferences: Array,
             recordType: String,
         },
         data() {
             return {
-                toggled: false,
                 i18n,
             }
         },
         methods: {
             toggle() {
-                this.$data.toggled = !this.$data.toggled
+                this.$refs.CoreModal.toggle()
             },
         },
     }

--- a/src/dns-lookup/templates/propagation_modal.vue
+++ b/src/dns-lookup/templates/propagation_modal.vue
@@ -15,31 +15,21 @@ limitations under the License.
 -->
 
 <template>
-    <div :class="`modal${toggled ? ' is-active' : ''}`">
-        <div class="modal-background"></div>
-        <div class="modal-card">
-            <header class="modal-card-head">
-                <p class="modal-card-title">
-                    {{ i18n.templates.propagationModal.title }}
-                </p>
-                <button class="delete" :aria-label="i18n.common.close" @click="toggle"></button>
-            </header>
-            <section class="modal-card-body">
-                <span v-for="part in splitUrlText(tutorial)">
-                    <span v-if="typeof part === 'string'" v-html="part"></span>
-                    <span v-else>
-                        <ExternalLink :text="part[0]" :link="part[1]"></ExternalLink>
-                    </span>
-                </span>
-            </section>
-        </div>
-    </div>
+    <CoreModal ref="CoreModal" :title="i18n.templates.propagationModal.title">
+        <span v-for="part in splitUrlText(tutorial)">
+            <span v-if="typeof part === 'string'" v-html="part"></span>
+            <span v-else>
+                <ExternalLink :text="part[0]" :link="part[1]"></ExternalLink>
+            </span>
+        </span>
+    </CoreModal>
 </template>
 
 <script>
     import i18n from "../i18n"
     import dataUrlParser from "../../shared/utils/dataUrlParser"
     import ExternalLink from "../../shared/templates/ext_link"
+    import CoreModal from "../../shared/templates/core_modal"
 
     let recordType, recordHost
     const deeplink = () => {
@@ -53,11 +43,11 @@ limitations under the License.
         name: "PropagationModal",
         components: {
             ExternalLink,
+            CoreModal,
         },
         data() {
             return {
                 tutorial: content(),
-                toggled: false,
                 i18n,
             }
         },
@@ -71,7 +61,7 @@ limitations under the License.
                 this.$data.tutorial = content()
             },
             toggle() {
-                this.$data.toggled = !this.$data.toggled
+                this.$refs.CoreModal.toggle()
             },
         },
     }

--- a/src/dns-lookup/templates/record_selection_modal.vue
+++ b/src/dns-lookup/templates/record_selection_modal.vue
@@ -16,31 +16,20 @@ limitations under the License.
 
 <template>
     <div>
-        <div :class="`modal${toggled ? ' is-active' : ''}`">
-            <div class="modal-background"></div>
-            <div class="modal-card">
-                <header class="modal-card-head">
-                    <p class="modal-card-title">
-                        {{ i18n.templates.recordSelectionModal.downloadRecords }}
-                    </p>
-                    <button class="delete" :aria-label="i18n.common.close" @click="toggle"></button>
-                </header>
-                <section class="modal-card-body">
-                    <div v-for="key in recordKeys">
-                        <input :id="`dl-select-${key}`" :ref="key" type="checkbox" checked>
-                        <label :for="`dl-select-${key}`">{{ key }} {{ i18n.common.records }}</label>
-                    </div>
-                    <a class="button is-link is-small" style="margin-top: 10px" @click="downloadRecords(false)">
-                        {{ i18n.templates.recordSelectionModal.downloadTextForm }}</a>
-                    <a class="button is-link is-small" style="margin-top: 10px" @click="copyRecords(false)">
-                        {{ i18n.templates.recordSelectionModal.copyTextForm }}</a>
-                    <a class="button is-link is-small" style="margin-top: 10px" @click="downloadRecords(true)">
-                        {{ i18n.templates.recordSelectionModal.downloadMd }}</a>
-                    <a class="button is-link is-small" style="margin-top: 10px" @click="copyRecords(true)">
-                        {{ i18n.templates.recordSelectionModal.copyMd }}</a>
-                </section>
+        <CoreModal ref="CoreModal" :title="i18n.templates.recordSelectionModal.downloadRecords">
+            <div v-for="key in recordKeys">
+                <input :id="`dl-select-${key}`" :ref="key" type="checkbox" checked>
+                <label :for="`dl-select-${key}`">{{ key }} {{ i18n.common.records }}</label>
             </div>
-        </div>
+            <a class="button is-link is-small" style="margin-top: 10px" @click="downloadRecords(false)">
+                {{ i18n.templates.recordSelectionModal.downloadTextForm }}</a>
+            <a class="button is-link is-small" style="margin-top: 10px" @click="copyRecords(false)">
+                {{ i18n.templates.recordSelectionModal.copyTextForm }}</a>
+            <a class="button is-link is-small" style="margin-top: 10px" @click="downloadRecords(true)">
+                {{ i18n.templates.recordSelectionModal.downloadMd }}</a>
+            <a class="button is-link is-small" style="margin-top: 10px" @click="copyRecords(true)">
+                {{ i18n.templates.recordSelectionModal.copyMd }}</a>
+        </CoreModal>
         <ClipboardModal ref="ClipboardModal" @toggle-root="toggle"></ClipboardModal>
     </div>
 </template>
@@ -50,6 +39,7 @@ limitations under the License.
     import i18n from "../i18n"
     import recordsDataset from "../data/records"
     import ClipboardModal from "./clipboard_modal"
+    import CoreModal from "../../shared/templates/core_modal"
 
     const recordKeys = Object.keys(recordsDataset)
 
@@ -57,17 +47,17 @@ limitations under the License.
         name: "RecordSelectionModal",
         components: {
             ClipboardModal,
+            CoreModal,
         },
         data() {
             return {
-                toggled: false,
                 i18n,
                 recordKeys,
             }
         },
         methods: {
             toggle() {
-                this.$data.toggled = !this.$data.toggled
+                this.$refs.CoreModal.toggle()
             },
             download(text, filename) {
                 const a = document.createElement("a")
@@ -83,7 +73,7 @@ limitations under the License.
                 const refs = Object.keys(this.$refs)
                 const allowedRecords = []
                 for (const i of refs) {
-                    if (i === "ClipboardModal") continue
+                    if (i === "ClipboardModal" || i === "CoreModal") continue
                     const input = this.$refs[i][0]
                     if (input.checked) allowedRecords.push(i)
                 }
@@ -104,7 +94,7 @@ limitations under the License.
                 document.execCommand("copy")
                 textarea.remove()
                 this.$refs.ClipboardModal.show(textReport)
-                this.$data.toggled = false
+                this.$refs.CoreModal.toggle()
             },
         },
     }

--- a/src/shared/i18n/en/common.ts
+++ b/src/shared/i18n/en/common.ts
@@ -1,0 +1,3 @@
+export default {
+    close: "close",
+} as {[key: string]: string}

--- a/src/shared/i18n/en/index.ts
+++ b/src/shared/i18n/en/index.ts
@@ -1,3 +1,4 @@
 import templates from "./templates"
+import common from "./common"
 
-export default { templates } as any
+export default { common, templates } as any

--- a/src/shared/templates/core_modal.vue
+++ b/src/shared/templates/core_modal.vue
@@ -22,7 +22,7 @@ limitations under the License.
                 <p class="modal-card-title">
                     {{ $props.title }}
                 </p>
-                <button class="delete" @click="toggle"></button>
+                <button class="delete" @click="toggle" :aria-label="i18n.common.close"></button>
             </header>
             <section class="modal-card-body">
                 <slot></slot>
@@ -32,6 +32,8 @@ limitations under the License.
 </template>
 
 <script>
+    import i18n from "../i18n"
+
     export default {
         name: "CoreModal",
         props: {
@@ -40,6 +42,7 @@ limitations under the License.
         data() {
             return {
                 toggled: false,
+                i18n,
             }
         },
         methods: {

--- a/src/shared/templates/core_modal.vue
+++ b/src/shared/templates/core_modal.vue
@@ -15,32 +15,36 @@ limitations under the License.
 -->
 
 <template>
-    <CoreModal ref="CoreModal" :title="i18n.templates.partExplanation.allMechanisms">
-        <p v-for="(value, key) in longDescriptions" :key="key">
-            <code class="slim">{{ key }}</code>: <span v-html="value"></span>
-        </p>
-    </CoreModal>
+    <div :class="`modal${toggled ? ' is-active' : ''}`">
+        <div class="modal-background" @click="toggle"></div>
+        <div class="modal-card">
+            <header class="modal-card-head">
+                <p class="modal-card-title">
+                    {{ $props.title }}
+                </p>
+                <button class="delete" @click="toggle"></button>
+            </header>
+            <section class="modal-card-body">
+                <slot></slot>
+            </section>
+        </div>
+    </div>
 </template>
 
 <script>
-    import i18n from "../i18n"
-    import longDescriptions from "../data/long_descriptions"
-    import CoreModal from "../../shared/templates/core_modal"
-
     export default {
-        name: "AllPartExplanations",
-        components: {
-            CoreModal,
+        name: "CoreModal",
+        props: {
+            title: String,
         },
         data() {
             return {
-                i18n,
-                longDescriptions,
+                toggled: false,
             }
         },
         methods: {
             toggle() {
-                this.$refs.CoreModal.toggle()
+                this.$data.toggled = !this.$data.toggled
             },
         },
     }

--- a/src/spf-explainer/templates/eval_modal.vue
+++ b/src/spf-explainer/templates/eval_modal.vue
@@ -15,46 +15,38 @@ limitations under the License.
 -->
 
 <template>
-    <div :class="`modal${toggled ? ' is-active' : ''}`">
-        <div class="modal-background"></div>
-        <div class="modal-card">
-            <header class="modal-card-head">
-                <p class="modal-card-title">
-                    {{ i18n.templates.evalModal.title }}
-                </p>
-                <button class="delete" @click="toggle"></button>
-            </header>
-            <section class="modal-card-body">
-                <p>
-                    <b>{{ i18n.templates.evalModal.in }}:</b>
-                </p>
-                <div v-if="message !== ''" class="notification is-primary">
-                    <button class="delete" @click="wipeMessage"></button>
-                    {{ message }}
-                </div>
-                <form autocomplete="on" @submit.prevent="runEval">
-                    <input v-model="text" class="input" type="text" :placeholder="i18n.templates.evalModal.in">
-                    <button class="button">
-                        {{ i18n.templates.evalModal.run }}
-                    </button>
-                </form>
-            </section>
+    <CoreModal ref="CoreModal" :title="i18n.templates.evalModal.title">
+        <p>
+            <b>{{ i18n.templates.evalModal.in }}:</b>
+        </p>
+        <div v-if="message !== ''" class="notification is-primary">
+            <button class="delete" @click="wipeMessage"></button>
+            {{ message }}
         </div>
-    </div>
+        <form autocomplete="on" @submit.prevent="runEval">
+            <input v-model="text" class="input" type="text" :placeholder="i18n.templates.evalModal.in">
+            <button class="button">
+                {{ i18n.templates.evalModal.run }}
+            </button>
+        </form>
+    </CoreModal>
 </template>
 
 <script>
     import i18n from "../i18n"
     import SPFSandbox from "../utils/spf_sandbox"
+    import CoreModal from "../../shared/templates/core_modal"
 
     export default {
         name: "EvalModal",
+        components: {
+            CoreModal,
+        },
         data() {
             return {
                 i18n,
                 text: "",
                 message: "",
-                toggled: false,
             }
         },
         methods: {
@@ -63,7 +55,7 @@ limitations under the License.
             },
             toggle() {
                 this.wipeMessage()
-                this.$data.toggled = !this.$data.toggled
+                this.$refs.CoreModal.toggle()
             },
             runEval() {
                 const res = SPFSandbox.eval(this.$data.text)

--- a/src/spf-explainer/templates/no_spf_records.vue
+++ b/src/spf-explainer/templates/no_spf_records.vue
@@ -15,36 +15,28 @@ limitations under the License.
 -->
 
 <template>
-    <div :class="`modal${toggled ? ' is-active' : ''}`">
-        <div class="modal-background"></div>
-        <div class="modal-card">
-            <header class="modal-card-head">
-                <p class="modal-card-title">
-                    {{ i18n.templates.noSpfRecords.title }}
-                </p>
-                <button class="delete" @click="toggle"></button>
-            </header>
-            <section class="modal-card-body">
-                {{ i18n.templates.noSpfRecords.description }}
-            </section>
-        </div>
-    </div>
+    <CoreModal ref="CoreModal" :title="i18n.templates.noSpfRecords.title">
+        {{ i18n.templates.noSpfRecords.description }}
+    </CoreModal>
 </template>
 
 <script>
     import i18n from "../i18n"
+    import CoreModal from "../../shared/templates/core_modal"
 
     export default {
         name: "NoSPFRecords",
+        components: {
+            CoreModal,
+        },
         data() {
             return {
                 i18n,
-                toggled: false,
             }
         },
         methods: {
             toggle() {
-                this.$data.toggled = !this.$data.toggled
+                this.$refs.CoreModal.toggle()
             },
         },
     }

--- a/src/spf-explainer/templates/part_explanation.vue
+++ b/src/spf-explainer/templates/part_explanation.vue
@@ -15,41 +15,32 @@ limitations under the License.
 -->
 
 <template>
-    <div :class="`modal${toggled ? ' is-active' : ''}`">
-        <div class="modal-background"></div>
-        <div class="modal-card">
-            <header class="modal-card-head">
-                <p class="modal-card-title">
-                    {{ i18n.templates.partExplanation.mechanism.replace("$", slug) }}
-                </p>
-                <button class="delete" @click="hide"></button>
-            </header>
-            <section class="modal-card-body" v-html="text"></section>
-        </div>
-    </div>
+    <CoreModal ref="CoreModal" :title="i18n.templates.partExplanation.mechanism.replace('$', slug)">
+        <span v-html="text"></span>
+    </CoreModal>
 </template>
 
 <script>
     import i18n from "../i18n"
+    import CoreModal from "../../shared/templates/core_modal"
 
     export default {
         name: "PartExplanation",
+        components: {
+            CoreModal,
+        },
         data() {
             return {
                 slug: "",
                 text: "",
-                toggled: false,
                 i18n,
             }
         },
         methods: {
             show(slug, text) {
-                this.$data.toggled = true
+                this.$refs.CoreModal.toggle()
                 this.$data.slug = slug.trim()
                 this.$data.text = text
-            },
-            hide() {
-                this.$data.toggled = false
             },
         },
     }


### PR DESCRIPTION
## Type of Change
<!-- What part of the source are you modifying? Remove the irrelevant options. -->
- **Shared Source:** A core modal template.
- **Tool Source:** Made both tools use the core modal template.

## What issue does this relate to?
Fixes: #79

### What should this PR do?
Add a core modal template with clicking the background also closing the modal.

### What are the acceptance criteria?
Just any bugs with the modals should be noted. I've tested this as I go along, so I don't see any reason why there would be.
