### PR TITLE
Add a 500ms delay to line generation to fix accidental highlights

### DIFF
--- a/src/spf-explainer/templates/app.vue
+++ b/src/spf-explainer/templates/app.vue
@@ -58,7 +58,7 @@ limitations under the License.
     import i18n from "../i18n"
     import cfDNS from "../../shared/utils/cfDNS"
     import SPFBase from "./spf_base"
-    import spawnLine from "../utils/line_spawn"
+    import { spawnLine } from "../utils/line_spawn"
     import NoSPFRecords from "./no_spf_records"
     import SPFSandbox from "../utils/spf_sandbox"
     import EvalModal from "./eval_modal"

--- a/src/spf-explainer/templates/spf.vue
+++ b/src/spf-explainer/templates/spf.vue
@@ -60,7 +60,7 @@ limitations under the License.
     import i18n from "../i18n"
     import cfDNS from "../../shared/utils/cfDNS"
     import explanations from "../data/explanations"
-    import spawnLine from "../utils/line_spawn"
+    import { spawnLine, setFreezeSpawning } from "../utils/line_spawn"
     import longDescriptions from "../data/long_descriptions"
     import PartExplanation from "./part_explanation"
     import SPFSandbox from "../utils/spf_sandbox"
@@ -100,9 +100,11 @@ limitations under the License.
                 this.$refs.PartExplanation.show(slug, longDescriptions[slug])
             },
             goToIndex(index) {
+                setFreezeSpawning(true)
                 const refArr = this.$refs[this.$data.links[index]]
                 const ref = refArr[refArr.length - 1]
                 ref.scrollIntoView()
+                setTimeout(() => setFreezeSpawning(false), 500)
             },
             markActive(index) {
                 const from = this.$refs[index][0]

--- a/src/spf-explainer/utils/line_spawn.ts
+++ b/src/spf-explainer/utils/line_spawn.ts
@@ -20,6 +20,10 @@ import LineGenerator from "./line_generator"
 // Defines the active line.
 let activeLine: LineGenerator | undefined
 
+// Freezes line spawing.
+let freezeSpawning = false
+export const setFreezeSpawning = (t: boolean) => { freezeSpawning = t }
+
 // Destroys the line.
 const destroy = () => {
     if (activeLine) activeLine.destroy()
@@ -27,7 +31,8 @@ const destroy = () => {
 }
 
 // Spawns the line.
-export default (lineRef: HTMLElement[] | undefined) => {
+export const spawnLine = (lineRef: HTMLElement[] | undefined) => {
+    if (freezeSpawning) return
     destroy()
     if (lineRef) activeLine = new LineGenerator(lineRef[0], lineRef[1])
 }


### PR DESCRIPTION
## Type of Change
<!-- What part of the source are you modifying? Remove the irrelevant options. -->
- **Tool Source:** SPF Explainer

## What issue does this relate to?
<!-- Use a GitHub keyword ('resolves #xx', 'fixes #xx', 'closes #xx') to automatically close the relevant issue. -->
Fixes: #95 

### What should this PR do?
<!-- Write a quick bullet point summary of the changes this PR should be making. -->
This delay doesn't feel slow to the end-user (since they likely will not have made a decision to highlight a record part within that time) and also fixes accidental highlighting by slightly moving the mouse immediately after record selection.

### What are the acceptance criteria?
<!-- Write a list of what should reviewers be checking before they approve this PR. -->
<!-- If there are UI changes, include before and after screenshots in a table for comparison. -->
Does it fix the issue? Does it feel smooth?