### PR TITLE
Add SPF button to DNS

### DIFF
--- a/src/dns-lookup/templates/mx_blacklist.vue
+++ b/src/dns-lookup/templates/mx_blacklist.vue
@@ -16,19 +16,27 @@ limitations under the License.
 
 <template>
     <div v-if="this.$props.hostname !== ''">
-        <hr style="margin: 5px">
+        <hr />
         <div v-if="blacklists.length !== 0">
-            <p v-for="item in blacklists" style="font-size: 11px">
-                <b>{{ item }}</b>
+            <p v-for="item in blacklists">
+                <small>
+                    <b>{{ item }}</b>
+                </small>
             </p>
         </div>
         <div v-else>
-            <p style="font-size: 11px">
-                <b>{{ i18n.templates.mxBlacklist.notBlacklisted }}</b>
+            <p>
+                <small>
+                    <b>{{ i18n.templates.mxBlacklist.notBlacklisted }}</b>
+                </small>
             </p>
         </div>
-        <p style="font-size: 11px">
-            <ExternalLink :text="i18n.templates.mxBlacklist.whatDoesItMean" link="https://www.techwalla.com/articles/what-does-it-mean-if-an-email-address-is-blacklisted"></ExternalLink>
+        <p>
+            <small>
+                <ExternalLink :text="i18n.templates.mxBlacklist.whatDoesItMean"
+                              link="https://www.techwalla.com/articles/what-does-it-mean-if-an-email-address-is-blacklisted"
+                ></ExternalLink>
+            </small>
         </p>
     </div>
 </template>

--- a/src/dns-lookup/templates/record.vue
+++ b/src/dns-lookup/templates/record.vue
@@ -76,6 +76,10 @@ limitations under the License.
                                             <b v-html="valueNode.description"></b>
                                         </p>
                                     </div>
+                                    <a v-if="valueNode.button"
+                                       :href="valueNode.button.link"
+                                       class="button is-primary is-mini"
+                                    >{{ valueNode.button.text }}</a>
                                 </td>
                             </tr>
                         </tbody>
@@ -323,6 +327,12 @@ limitations under the License.
                                     }
                                     if (txtFragments[truncated]) data.description = txtFragments[truncated]
                                     if (part.length > 20) data.values[0].truncated = truncated
+                                    if (truncated === "v=spf1") {
+                                        data.button = {
+                                            link: `https://www.digitalocean.com/community/tools/spf?domain=${text}`,
+                                            text: "Explore and evaluate SPF record",
+                                        }
+                                    }
                                 } else if (key === "DMARC") {
                                     const split = part.split("=")
                                     const whitespaceGone = split[0].trim()

--- a/src/dns-lookup/templates/record.vue
+++ b/src/dns-lookup/templates/record.vue
@@ -62,7 +62,7 @@ limitations under the License.
                                         <div v-else>
                                             {{ value.result }}
                                             <div v-if="value.hostname">
-                                                <hr style="margin: 5px">
+                                                <hr />
                                                 <WHOIS :ip="value.ip"></WHOIS>
                                                 <div v-if="$props.recordType === 'MX'">
                                                     <MXBlacklist :ip="value.ip" :hostname="value.hostname ? value.hostname : ''"></MXBlacklist>
@@ -71,9 +71,11 @@ limitations under the License.
                                         </div>
                                     </div>
                                     <div v-if="valueNode.description">
-                                        <hr style="margin: 5px" />
-                                        <p style="font-size: 11px">
-                                            <b v-html="valueNode.description"></b>
+                                        <hr />
+                                        <p>
+                                            <small>
+                                                <b v-html="valueNode.description"></b>
+                                            </small>
                                         </p>
                                     </div>
                                     <a v-if="valueNode.button"

--- a/src/dns-lookup/templates/whois.vue
+++ b/src/dns-lookup/templates/whois.vue
@@ -15,25 +15,43 @@ limitations under the License.
 -->
 
 <template>
-    <span v-if="done">
-        <p style="font-size: 11px">
-            <b>{{ i18n.templates.whois.owner }}:</b> <a @click="toggleExpand">{{ netname }}</a>
-            <span
-                id="countryInfo"
-                v-tippy
-                :class="`flag-icon flag-icon-${countryCode}`"
-                :title="countryInfo"
-            />
+    <div v-if="done">
+        <p>
+            <small>
+                <b>{{ i18n.templates.whois.owner }}:</b> <a @click="toggleExpand">{{ netname }}</a>
+                <span
+                    id="countryInfo"
+                    v-tippy
+                    :class="`flag-icon flag-icon-${countryCode}`"
+                    :title="countryInfo"
+                />
+            </small>
         </p>
-        <span v-if="expand">
-            <p style="font-size: 11px"><b>ASN:</b> {{ asn }}</p>
-            <p style="font-size: 11px"><b>CIDR:</b> {{ cidr }}</p>
-            <p style="font-size: 11px"><b>{{ i18n.templates.whois.abuseContact }}:</b> {{ abuse }}</p>
-        </span>
-    </span>
-    <span v-else>
-        <p style="font-size: 11px"><i>{{ i18n.templates.whois.loading }}</i></p>
-    </span>
+        <div v-if="expand">
+            <p>
+                <small>
+                    <b>ASN:</b> {{ asn }}
+                </small>
+            </p>
+            <p>
+                <small>
+                    <b>CIDR:</b> {{ cidr }}
+                </small>
+            </p>
+            <p>
+                <small>
+                    <b>{{ i18n.templates.whois.abuseContact }}:</b> {{ abuse }}
+                </small>
+            </p>
+        </div>
+    </div>
+    <div v-else>
+        <p>
+            <small>
+                <i>{{ i18n.templates.whois.loading }}</i>
+            </small>
+        </p>
+    </div>
 </template>
 
 <script>

--- a/src/shared/scss/_tables.scss
+++ b/src/shared/scss/_tables.scss
@@ -77,6 +77,18 @@ $table-border: $thick-border-size solid $border;
 
         p {
           margin: 0;
+
+          small {
+            font-size: $font-size * .75;
+          }
+        }
+
+        hr {
+          margin: ($margin / 4) 0;
+
+          @media (min-width: $breakpoint) {
+            margin: ($margin / 2) 0;
+          }
         }
 
         .button.is-mini {

--- a/src/shared/scss/_tables.scss
+++ b/src/shared/scss/_tables.scss
@@ -78,6 +78,13 @@ $table-border: $thick-border-size solid $border;
         p {
           margin: 0;
         }
+
+        .button.is-mini {
+          font-size: $font-size * .75;
+          height: $margin * 2;
+          line-height: $margin * 2;
+          margin-top: $margin / 2;
+        }
       }
     }
   }


### PR DESCRIPTION
## Type of Change

- **Shared Source:** Styling
- **Tool Source:** DNS

## What issue does this relate to?

Resolves #84 

### What should this PR do?

 - Adds a button to the DNS tool in TXT records if an SPF record is found that deep links to the SPF tool

### What are the acceptance criteria?

 - When a domain has an SPF TXT record in the DNS tool, the SPF button shows and links to that domain on the SPF tool