### PR TITLE
Disable pointer events on SVG line container

### DIFF
--- a/src/spf-explainer/utils/line_generator.ts
+++ b/src/spf-explainer/utils/line_generator.ts
@@ -88,6 +88,7 @@ export default class LineGenerator {
         div.style.top = "0"
         div.style.left = "0"
         div.style.overflow = "show"
+        div.style.pointerEvents = "none"
         document.body.appendChild(div)
         return div
     }
@@ -113,7 +114,7 @@ export default class LineGenerator {
     public setup() {
         // Locks the initialiser.
         lock = true
-    
+
         // Gets the positions of A/B.
         const aRect = this.a.getBoundingClientRect() as DOMRect
         const bRect = this.b.getBoundingClientRect()


### PR DESCRIPTION
## Type of Change

- **Tool Source:** SPF

## What issue does this relate to?

N/A

### What should this PR do?

Disable pointer events on the SVG line div that was causing issues on Firefox.
![image](https://user-images.githubusercontent.com/12371363/65884662-27435d00-e391-11e9-9f5f-f3a39b909d5a.png)

### What are the acceptance criteria?

 - Hovering over a line then attempting to interact with the main nav works fine