### PR TITLE
Add CNAME records to the lookup

### DIFF
--- a/src/dns-lookup/data/records.ts
+++ b/src/dns-lookup/data/records.ts
@@ -38,6 +38,11 @@ export default {
         url: "https://help.fasthosts.co.uk/app/answers/detail/a_id/1548/~/dns-aaaa-records",
         expectsHost: true,
     },
+    CNAME: {
+        info: i18n.data.records.CNAME,
+        url: "https://support.google.com/a/answer/112037?hl=en",
+        expectsHost: true,
+    },
     CAA: {
         info: i18n.data.records.CAA,
         url: "https://www.digitalocean.com/docs/networking/dns/how-to/caa/",
@@ -58,7 +63,7 @@ export default {
     },
     SSHFP: {
         info: i18n.data.records.SSHFP,
-        url: "https://en.wikipedia.org/wiki/SSHFP_record",   
+        url: "https://en.wikipedia.org/wiki/SSHFP_record",
     },
     TLSA: {
         info: i18n.data.records.TLSA,

--- a/src/dns-lookup/i18n/en/data/records.ts
+++ b/src/dns-lookup/i18n/en/data/records.ts
@@ -3,6 +3,7 @@ export default {
     TXT: "TXT records are a type of DNS record that contains text information for sources outside of your domain.",
     MX: "A mail exchanger record (MX record) specifies the mail server responsible for accepting email messages on behalf of a domain name.",
     AAAA: "AAAA records behave the same as A records but for IPv6.\nThey are used to point a domain or subdomain to a IPv6 address.",
+    CNAME: "CNAME records are a DNS record that allows one domain too be mapped as an alias to another canonical domain name.",
     CAA: "CAA records allow domain owners to specify which Certificate Authorities (CAs) are permitted to issue certificates.",
     NS: "NS stands for \"name server\" and this record indicates which DNS server is authoritative for that domain (which server contains the actual DNS records).\nA domain will often have multiple NS records which can indicate primary and backup name servers for that domain.",
     SRV: "A Service record (SRV record) is a specification of data in the Domain Name System defining the location, i.e. the hostname and port number, of servers for specified services.",


### PR DESCRIPTION
## Type of Change

- **Tool Source:** DNS Lookup

## What issue does this relate to?

PDOCS-583

### What should this PR do?

Adds CNAMEs to the DNS lookup tool

### What are the acceptance criteria?

Be able to see CNAMEs when looking up a subdomain that uses them (test.cdnjs.dev -> google.com)
