### PR TITLE
Show validation error/comment from Cloudflare

### DIFF
--- a/src/shared/utils/sanitize.ts
+++ b/src/shared/utils/sanitize.ts
@@ -1,0 +1,28 @@
+/*
+Copyright 2019 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export default (text: string) => {
+    const map = [
+        [/</g, "&lt;"],
+        [/>/g, "&gt;"],
+        [/'/g, "&#39;"],
+        [/"/g, "&#34;"],
+    ]
+    map.forEach(item => {
+        text = text.replace(item[0], item[1] as string)
+    })
+    return text
+}

--- a/src/shared/utils/validateDomain.ts
+++ b/src/shared/utils/validateDomain.ts
@@ -1,0 +1,50 @@
+/*
+Copyright 2019 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import cfDNS from "./cfDNS"
+import i18n from "../i18n"
+
+const stripHttps = /(https*:\/\/)*(.+)*/
+const isHostname = /.*\.[a-z]+/
+
+export default async (name: string) => {
+    // Strip http(s) from the input
+    const regexpExec = stripHttps.exec(name.toLowerCase())
+    if (regexpExec === null) return [null, i18n.common.invalidDomain]
+
+    // Attempt to determine the hostname
+    const text = regexpExec[2] ? regexpExec[2].replace(/\//g, "") : ""
+    if (!text.match(isHostname)) return [null, i18n.common.invalidDomain]
+
+    // Talk to Cloudflare to validate the domain exists
+    const domainLookup = await cfDNS(text, "NULL")
+    let json
+    try {
+        json = await domainLookup.json()
+    } catch {
+        // Sometimes Cloudflare's DNS sends invalid JSON in the event that it is invalid.
+        // That has happened here.
+        return [null, i18n.common.invalidDomain]
+    }
+    if (json.Status !== 0) {
+        let msg = i18n.common.invalidDomain
+        if (json.Comment) msg += `</p><p>${json.Comment}`
+        return [null, msg]
+    }
+
+    // It's legit
+    return [text, null]
+}

--- a/src/shared/utils/validateDomain.ts
+++ b/src/shared/utils/validateDomain.ts
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import cfDNS from "./cfDNS"
+import sanitize from "./sanitize"
 import i18n from "../i18n"
 
 const stripHttps = /(https*:\/\/)*(.+)*/
@@ -41,7 +42,7 @@ export default async (name: string) => {
     }
     if (json.Status !== 0) {
         let msg = i18n.common.invalidDomain
-        if (json.Comment) msg += `</p><p>${json.Comment}`
+        if (json.Comment) msg += `</p><p>${sanitize(json.Comment)}`
         return [null, msg]
     }
 

--- a/src/spf-explainer/i18n/en/templates/app.ts
+++ b/src/spf-explainer/i18n/en/templates/app.ts
@@ -3,5 +3,5 @@ export default {
     description: `A tool that explains a domain’s SPF records. Search a domain and either explore its records or evaluate an IP for mail sending.`,
     eval: "Evaluate",
     whatDoTheyDo: "What are all the SPF mechanisms and what do they all do?",
-    fetchError: "An error occurred whilst attempt to fetch the SPF records",
+    fetchError: "An error occurred whilst attempting to fetch the SPF records.",
 } as {[key: string]: string}

--- a/src/spf-explainer/i18n/en/templates/app.ts
+++ b/src/spf-explainer/i18n/en/templates/app.ts
@@ -3,4 +3,5 @@ export default {
     description: `A tool that explains a domain’s SPF records. Search a domain and either explore its records or evaluate an IP for mail sending.`,
     eval: "Evaluate",
     whatDoTheyDo: "What are all the SPF mechanisms and what do they all do?",
+    fetchError: "An error occurred whilst attempt to fetch the SPF records",
 } as {[key: string]: string}

--- a/src/spf-explainer/templates/spf.vue
+++ b/src/spf-explainer/templates/spf.vue
@@ -62,6 +62,7 @@ limitations under the License.
 <script>
     import i18n from "../i18n"
     import cfDNS from "../../shared/utils/cfDNS"
+    import sanitize from "../../shared/utils/sanitize"
     import explanations from "../data/explanations"
     import { spawnLine, setFreezeSpawning } from "../utils/line_spawn"
     import longDescriptions from "../data/long_descriptions"
@@ -119,14 +120,6 @@ limitations under the License.
                 const ref = refArr[refArr.length - 1]
                 spawnLine([from, ref])
             },
-            sanitize(data) {
-                const lt = /</g,
-                      gt = />/g,
-                      ap = /'/g,
-                      ic = /"/g
-
-                return data.replace(lt, "&lt;").replace(gt, "&gt;").replace(ap, "&#39;").replace(ic, "&#34;")
-            },
             async init() {
                 // These are the parts which are given to Vue in a way which is easy to iterate.
                 const parts = []
@@ -141,7 +134,7 @@ limitations under the License.
                 for (const part of dataSplit) {
                     // Ignore blank parts.
                     if (part === "") continue
-                    
+
                     // Defines if a match was found.
                     let done = false
 
@@ -159,7 +152,7 @@ limitations under the License.
                             // Defines the regex match for the URL to get the record to include from.
                             let lookup = match[1] ? match[1].replace(/\" \"/g, "") : undefined
                             if (recursive && lookup !== "") {
-                                // Looks up the TXT record for the domain specified. If it exists and getting it was ok, set include to the data. 
+                                // Looks up the TXT record for the domain specified. If it exists and getting it was ok, set include to the data.
                                 const res = await cfDNS(lookup, "TXT")
                                 if (res.ok) {
                                     const json = await res.json()
@@ -246,7 +239,7 @@ limitations under the License.
                         if (key.match(/^ip[0-9]$/)) key = `${key}:<IP range>`
                         for (const chunkItem of chunkArr) {
                             ips.push(chunkItem[0][0])
-                            const san = this.sanitize(chunkItem[0][1])
+                            const san = sanitize(chunkItem[0][1])
                             if (commaSepList.includes(san)) continue
                             commaSepList.push(san)
                             this.$data.links[chunkItem[0][0]] = key
@@ -261,7 +254,7 @@ limitations under the License.
                             if (numberMatches) {
                                 for (const n of numberMatches) {
                                     const x = Number(n.substr(1).slice(0, -1))
-                                    value = v.replace(n, this.sanitize(chunkItem[0][x]))
+                                    value = v.replace(n, sanitize(chunkItem[0][x]))
                                 }
                             }
                             this.$data.links[chunkItem[0][0]] = chunkItem[0][0]


### PR DESCRIPTION
## Type of Change

- **Shared Source:** New validateDomain util
- **Tool Source:** DNS & SPF

## What issue does this relate to?

Resolves #123 

### What should this PR do?

Shows the Comment that Cloudflare provides when the domain validation lookup fails. A good example of this is a domain that exists but fails DNSSEC validation, such as `dnssec-failed.org`.

### What are the acceptance criteria?

 - Both tools validate domains correctly
 - If a bad DNSSEC domain is entered, the comment from Cloudflare will show
    - Can be tested with `dnssec-failed.org`

![image](https://user-images.githubusercontent.com/12371363/68311408-6ad46980-00a9-11ea-930d-5ff02f7eb9e5.png)