### PR TITLE
Hide helpfulness box on landing

### DIFF
--- a/src/dns-lookup/scss/style.scss
+++ b/src/dns-lookup/scss/style.scss
@@ -20,6 +20,12 @@ $header: #005ff8;
 @import "~do-bulma/src/style";
 
 .do-bulma {
+  &.landing {
+    + .helpfulness-cont {
+      display: none;
+    }
+  }
+
   h3.title.is-3 {
     font-family: $bold-font-family;
   }

--- a/src/dns-lookup/templates/app.vue
+++ b/src/dns-lookup/templates/app.vue
@@ -15,7 +15,7 @@ limitations under the License.
 -->
 
 <template>
-    <div class="all do-bulma">
+    <div :class="`all do-bulma${firstSearch? ' landing' : ''}`">
         <Landing
             v-if="firstSearch"
             :title="i18n.templates.app.title"

--- a/src/spf-explainer/scss/style.scss
+++ b/src/spf-explainer/scss/style.scss
@@ -18,6 +18,12 @@ $header: #0071fe;
 @import "~do-bulma/src/style";
 
 .do-bulma {
+  &.landing {
+    + .helpfulness-cont {
+      display: none;
+    }
+  }
+
   .main.container {
     h5.title.is-5 {
       line-height: 1.35;

--- a/src/spf-explainer/templates/app.vue
+++ b/src/spf-explainer/templates/app.vue
@@ -15,7 +15,7 @@ limitations under the License.
 -->
 
 <template>
-    <div class="all do-bulma">
+    <div :class="`all do-bulma${firstSearch && !loading? ' landing' : ''}`">
         <Landing
             v-if="firstSearch && !loading"
             :title="i18n.templates.app.title"


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Both

## What issue does this relate to?

Internal PR 1415

### What should this PR do?

Adds a landing class to the top-level app container that then hides the helpfulness box that we will soon be rendering on all tool pages.

### What are the acceptance criteria?

I've tested this locally with 1415 pulled down, it works.