### PR TITLE
Fix undefined ref errors for modals

### DIFF
--- a/src/spf-explainer/templates/app.vue
+++ b/src/spf-explainer/templates/app.vue
@@ -30,9 +30,6 @@ limitations under the License.
         </Landing>
 
         <div v-else>
-            <NoSPFRecords ref="NoSPFRecords"></NoSPFRecords>
-            <AllPartExplanations ref="AllPartExplanations"></AllPartExplanations>
-
             <Header
                 :title="i18n.templates.app.title"
                 button-id="DomainSearch"
@@ -81,6 +78,8 @@ limitations under the License.
             <Footer></Footer>
         </div>
 
+        <NoSPFRecords ref="NoSPFRecords"></NoSPFRecords>
+        <AllPartExplanations ref="AllPartExplanations"></AllPartExplanations>
         <ErrorModal ref="ErrorModal" :message="errorMessage"></ErrorModal>
     </div>
 </template>


### PR DESCRIPTION
## Type of Change

- **Tool Source:** SPF: Modals

## What issue does this relate to?

Closes #138

### What should this PR do?

Fixes an undefined ref error seen in production by moving the modal components w/ refs outside the if-else logic in the app template.

### What are the acceptance criteria?

If a domain has no SPF records or a lookup fails, from the landing state, the tool with correctly show the error modals without having an undefined ref error in console.