### PR TITLE
Bump do-vue & do-bulma to fix landing overflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1823,9 +1823,9 @@
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
     },
     "bulma": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.9.1.tgz",
-      "integrity": "sha512-LSF69OumXg2HSKl2+rN0/OEXJy7WFEb681wtBlNS/ulJYR27J3rORHibdXZ6GVb/vyUzzYK/Arjyh56wjbFedA=="
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.9.2.tgz",
+      "integrity": "sha512-e14EF+3VSZ488yL/lJH0tR8mFWiEQVCMi/BQUMi2TGMBOk+zrDg4wryuwm/+dRSHJw0gMawp2tsW7X1JYUCE3A=="
     },
     "cache-base": {
       "version": "1.0.1",
@@ -2932,14 +2932,14 @@
       }
     },
     "do-bulma": {
-      "version": "git+https://github.com/do-community/do-bulma.git#5dc30507ec3d0bc81bdbd88474afd6068fc72acd",
+      "version": "git+https://github.com/do-community/do-bulma.git#a78af3628ed9a6599e8f0677affaf918e22ac954",
       "from": "git+https://github.com/do-community/do-bulma.git",
       "requires": {
         "bulma": "^0.9.1"
       }
     },
     "do-vue": {
-      "version": "git+https://github.com/do-community/do-vue.git#2440d4b1c633a52deb10735b2c978d4c287d4fd7",
+      "version": "git+https://github.com/do-community/do-vue.git#0554c536cdc5bf2db889a44c162a4837c696c69b",
       "from": "git+https://github.com/do-community/do-vue.git",
       "requires": {
         "jsdom": "^16.4.0",

--- a/src/dns-lookup/index.html
+++ b/src/dns-lookup/index.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ limitations under the License.
     </block>
     <block name="content">
         <div id="app"></div>
+    </block>
+    <block name="script">
         <script src="mount.js"></script>
     </block>
 </extends>

--- a/src/spf-explainer/index.html
+++ b/src/spf-explainer/index.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ limitations under the License.
     </block>
     <block name="content">
         <div id="app"></div>
+    </block>
+    <block name="script">
         <script src="mount.js"></script>
     </block>
 </extends>


### PR DESCRIPTION
## Type of Change

- **Tool Source:** HTML template in both tools
- **Something else:** Deps

## What issue does this relate to?

cc https://github.com/do-community/do-vue/pull/24 / https://github.com/do-community/do-bulma/pull/27

### What should this PR do?

Fixes the landing design overflowing into the community footer by bumping do-vue & do-bulma to fixed versions

### What are the acceptance criteria?

- Landing design does not overflow into footer on DNS/SPF tools