### PR TITLE
Handle DNS comments on error that are an array

### DIFF
--- a/src/dns-lookup/templates/app.vue
+++ b/src/dns-lookup/templates/app.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2021 DigitalOcean
+Copyright 2022 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -184,6 +184,8 @@ limitations under the License.
                     this.$data.linked = null
                     this.$data.data = domain
                     await this.searchWait()
+                } catch(e) {
+                    console.error(e)
                 } finally {
                     el.classList.remove("is-loading")
                     this.$data.siteLoading = false

--- a/src/shared/utils/validateDomain.ts
+++ b/src/shared/utils/validateDomain.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 DigitalOcean
+Copyright 2022 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ export default async (name: string) => {
     }
     if (json.Status !== 0) {
         let msg = i18n.common.invalidDomain
-        if (json.Comment) msg += `</p><p>${sanitize(json.Comment)}`
+        if (json.Comment) msg += `</p><p>${sanitize(json.Comment.toString())}`
         return [null, msg]
     }
 

--- a/src/spf-explainer/templates/app.vue
+++ b/src/spf-explainer/templates/app.vue
@@ -208,6 +208,8 @@ limitations under the License.
                     this.$data.loading = true
                     spawnLine(undefined)
                     await this.lookup(domain, j)
+                } catch(e) {
+                    console.error(e)
                 } finally {
                     el.classList.remove("is-loading")
                     this.$data.loading = false


### PR DESCRIPTION
## Type of Change

- **Shared Source:** Domain validation
- **Tool Source:** Domain lookup

## What issue does this relate to?

Fixes #177 

### What should this PR do?

Domains that fail the initial lookup sometimes return an array of comments. The logic was not setup to handle this before, but has now been updated to ensure comments are forced to a string before being sanitized.

### What are the acceptance criteria?

Looking up a domain that fails with a comment array, such as `dnssec-failed.org`, shows an error modal in the UI, rather than silently failing.