### PR TITLE
Fix missing spaces in SPF records

### DIFF
--- a/src/spf-explainer/templates/spf.vue
+++ b/src/spf-explainer/templates/spf.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2019 DigitalOcean
+Copyright 2023 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,7 +18,10 @@ limitations under the License.
     <div v-if="!loading">
         <h5 class="title is-5">
             <span v-for="(_, key) in links" :key="key" :ref="key">
-                <a @click="goToIndex(key)" @mouseover="markActive(key)">{{ key }} </a>
+                <a @click="goToIndex(key)" @mouseover="markActive(key)">
+                    {{ key }}
+                </a>
+                {{ " " }}
             </span>
         </h5>
         <div v-if="parts.length === 0">
@@ -29,6 +32,7 @@ limitations under the License.
             <div :ref="part[0]">
                 <p>
                     <code class="slim">{{ part[0] }}</code>
+                    {{ " " }}
                     <a
                         v-if="part[4] !== undefined && longDescriptionExists(part[4])"
                         @click="displayLongDescription(part[4])"


### PR DESCRIPTION
## Type of Change

- **Tool Source:** SPF records

## What issue does this relate to?

N/A

### What should this PR do?

Fixes missing spaces between parts of the SPF records, and also a missing space between the explanation and the help icon.

### What are the acceptance criteria?

Each part of the SPF record includes a space before the next section.

| Before | After |
|-|-|
| ![image](https://github.com/do-community/dns-tool/assets/12371363/5b23b934-64c0-4837-a2b0-17c64cb566ed) | ![image](https://github.com/do-community/dns-tool/assets/12371363/22dcdeb9-267a-420f-877a-274122c75b45) |